### PR TITLE
fix broken snapMode by adding highlightrange to update current index

### DIFF
--- a/qml/pages/CertListPage.qml
+++ b/qml/pages/CertListPage.qml
@@ -22,6 +22,7 @@ Page {
         model: myapp.certs.size
         visible: myapp.certs.size > 0
         snapMode: ListView.SnapOneItem
+        highlightRangeMode: ListView.StrictlyEnforceRange  //to update current index, needed for snapMode to work
         delegate: Item {
             width: root.width
             CertItem {


### PR DESCRIPTION
Currently the list view does not snap to a certain element. This is only relevant for more than two codes, but nevertheless then not good for usability.

According to the [doc](https://api-docs.ubports.com/sdk/apps/qml/QtQuick/ListView.html?highlight=listview#sdk-qtquick-listview-snapmode), snapMode only works with the current index being updated. This can be done by setting `highlightRangeMode` to `ListView.StrictlyEnforceRange`.

This PR will add this property fixing the snapMode.