### PR TITLE
reduce timer intervall for better scanning, drop log entry

### DIFF
--- a/qml/pages/QRCodeScanner.qml
+++ b/qml/pages/QRCodeScanner.qml
@@ -26,7 +26,7 @@ Page {
 
     Timer {
         id: captureTimer
-        interval: 2000
+        interval: 500
         repeat: true
         running: active && !scanner.hasResult
         onTriggered: {
@@ -39,11 +39,10 @@ Page {
                 if (scanner.hasResult) {
                     page.done()
                 }
-                
+
             } else {
                 camera.start()
             }
-            console.log("timer running", running)
         }
     }
 


### PR DESCRIPTION
I tinkered around a little bit and found with the timer set to 500ms scanning works much better. Not always perfect, but better.

This PR will also drop the console.log line since this would spam the log with a interval of 500 ms.